### PR TITLE
Don't used named arguments when calling run

### DIFF
--- a/vars/virtualenv.groovy
+++ b/vars/virtualenv.groovy
@@ -1,7 +1,7 @@
 def create(String python, String path = "venv", boolean installRequirements = true) {
   sh("virtualenv -p ${python} ${path}")
   if (installRequirements && fileExists("requirements.txt")) {
-    run(path:path, command:"pip install -r requirements.txt")
+    run(path, "pip install -r requirements.txt")
   }
 }
 


### PR DESCRIPTION
For some reason, Jenkins refuses to execute `run` when using named
arguments. There is no stacktrace and my groovy-fu is not good enough
to understand why it would fail. Regardless, the call also works fine
without named arguments.

ping @AbletonDevTools/gotham-city