### PR TITLE
Introduce VirtualEnv class

### DIFF
--- a/src/com/ableton/VirtualEnv.groovy
+++ b/src/com/ableton/VirtualEnv.groovy
@@ -1,0 +1,26 @@
+package com.ableton
+
+
+class VirtualEnv implements Serializable {
+  def script
+  String destDir
+
+
+  VirtualEnv(script, String python) {
+    this.script = script
+    final PATH_SEP = script.isUnix() ? "/" : "\\"
+    this.destDir = script.pwd(tmp:true) +
+      PATH_SEP +
+      script.env.BUILD_NUMBER +
+      PATH_SEP +
+      python
+  }
+
+
+  def run(String command) {
+    script.sh("""
+      . ${destDir}/bin/activate
+      ${command}
+    """)
+  }
+}

--- a/vars/virtualenv.groovy
+++ b/vars/virtualenv.groovy
@@ -1,16 +1,8 @@
-def create(String python, String destDir) {
-  sh("virtualenv --python=${python} ${destDir}")
-}
+import com.ableton.VirtualEnv
 
 
-def installRequirements(String destDir) {
-  run(destDir, "pip install -r requirements.txt")
-}
-
-
-def run(String destDir, String command) {
-  sh("""
-    . ./${destDir}/bin/activate
-    ${command}
-  """)
+def create(script, String python) {
+  venv = new VirtualEnv(script, python)
+  venv.script.sh("virtualenv --python=${python} ${venv.destDir}")
+  return venv
 }


### PR DESCRIPTION
This commit introduces a class for VirtualEnv which keeps an internal
reference to the virtualenv destination dir. Also note that this
directory is no longer configurable, but instead is safely tucked away
in a temporary directory.

The virtualenv singleton has also been changed to remove all functions
other than create(), which now returns a new instance of the
VirtualEnv class.

ptal @AbletonDevTools/gotham-city, thanks!