### PR TITLE
Introduce new singleton/class to install Python

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.github.AbletonDevTools:jenkins-pipeline-mocks:0.2.0'
+  compile 'com.github.AbletonDevTools:jenkins-pipeline-mocks:0.4.1'
   compile 'org.codehaus.groovy:groovy-all:2.4.10'
 
   testCompile 'junit:junit:4.12'

--- a/src/com/ableton/PythonBuilder.groovy
+++ b/src/com/ableton/PythonBuilder.groovy
@@ -1,0 +1,101 @@
+package com.ableton
+
+
+class PythonBuilder implements Serializable {
+  @SuppressWarnings('FieldTypeRequired')
+  def script = null
+  /**
+   * Python major version to download (required value). Example: '3.7.0'
+   */
+  String version = null
+
+  /**
+   * Mirror to use when downloading Python.
+   */
+  String downloadMirror = 'https://www.python.org/ftp/python'
+  /**
+   * Method to use to download Python. Currently supported methods include:
+   * - 'curl': Requires curl to be installed on the build node.
+   * - 'httpRequest': Requires the Jenkins HTTP Request Plugin to be installed (default).
+   */
+  String downloadWith = 'httpRequest'
+  /**
+   * Number of parallel jobs to use when building Python (ie, `make -jN`). Default: '1'
+   */
+  String makeJobs = '1'
+  /**
+   * Python version revision, optional. This value is appended to the major version, but
+   * because of the way that Python's downloads are organized, this value must be separate
+   * from the major version. So for Python 3.7.0a4, use '3.7.0' for the version and 'a4'
+   * for the revision.
+   */
+  String revision = ''
+
+  String install() {
+    // Sanity check required values
+    assert script
+    assert version
+
+    if (!script.isUnix()) {
+      throw new UnsupportedOperationException('This function is only supported on Unix')
+    }
+
+    String sourcesTarball = download()
+    String sourcesPath = extract(sourcesTarball)
+    return build(sourcesPath)
+  }
+
+  protected String pythonBaseName() {
+    return 'Python-' + version + revision
+  }
+
+  protected String tempDir() {
+    return script.pwd(tmp: true)
+  }
+
+  protected String download() {
+    String downloadUrl = downloadMirror + '/' + version +
+      '/' + pythonBaseName() + '.tgz'
+    String outputFile = script.pwd(tmp: true) + '/' + pythonBaseName() + '.tgz'
+    script.echo 'Downloading python from: ' + downloadUrl
+
+    switch (downloadWith) {
+      case 'curl':
+        script.sh "curl -s -o ${outputFile} ${downloadUrl}"
+        break
+      case 'httpRequest':
+        script.httpRequest(outputFile: outputFile, url: downloadUrl)
+        break
+      default:
+        script.error 'Unknown downloadWith type: ' + downloadWith
+    }
+
+    return outputFile
+  }
+
+  protected String extract(String sourcesTarball) {
+    script.echo 'Extracting python sources'
+    script.dir(tempDir()) {
+      script.sh 'tar xfz ' + sourcesTarball
+    }
+    return tempDir() + '/' + pythonBaseName()
+  }
+
+  protected String build(String sourcesPath) {
+    // Ensure that makeJobs is not an empty string, since make is a bit dumb and running
+    // `make -j` will spawn one job for every file, potentially forkbombing the node.
+    if (!makeJobs || !makeJobs.toInteger()) {
+      throw new IllegalArgumentException('Invalid argument for makeJobs: ' + makeJobs)
+    }
+
+    script.echo 'Building python from: ' + sourcesPath
+    String installPath = script.pwd(tmp: true) + '/' + pythonBaseName()
+    script.dir(sourcesPath) {
+      script.sh './configure --prefix=' + installPath
+      script.sh 'make -j' + makeJobs
+      script.sh 'make install'
+      script.deleteDir()
+    }
+    return installPath
+  }
+}

--- a/test/com/ableton/PythonBuilderTest.groovy
+++ b/test/com/ableton/PythonBuilderTest.groovy
@@ -1,0 +1,102 @@
+package com.ableton
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+
+
+class PythonBuilderTest extends BasePipelineTest {
+  @SuppressWarnings('FieldTypeRequired')
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+
+    this.script = loadScript('test/resources/EmptyPipeline.groovy')
+    assertNotNull(script)
+
+    helper.with {
+      registerAllowedMethod('error', [String], JenkinsMocks.error)
+      registerAllowedMethod('deleteDir', [], null)
+      registerAllowedMethod('httpRequest', [Map], null)
+      registerAllowedMethod('isUnix', [], JenkinsMocks.isUnix)
+      registerAllowedMethod('pwd', [Map], JenkinsMocks.pwd)
+      registerAllowedMethod('sh', [String], JenkinsMocks.sh)
+    }
+  }
+
+  @Test
+  void install() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1.0.0')
+    String pythonPath = pb.tempDir() + '/' + pb.pythonBaseName()
+    JenkinsMocks.addShMock('tar xfz ' + pythonPath + '.tgz', '', 0)
+    JenkinsMocks.addShMock('./configure --prefix=' + pythonPath, '', 0)
+    JenkinsMocks.addShMock('make -j1', '', 0)
+    JenkinsMocks.addShMock('make install', '', 0)
+    assertEquals(pythonPath, pb.install())
+  }
+
+  @Test(expected = Exception)
+  void installWithBuildError() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1.0.0')
+    String pythonPath = pb.tempDir() + '/' + pb.pythonBaseName()
+    JenkinsMocks.addShMock('tar xfz ' + pythonPath + '.tgz', '', 0)
+    JenkinsMocks.addShMock('./configure --prefix=' + pythonPath, '', 0)
+    JenkinsMocks.addShMock('make -j1', '', 1)
+    pb.install()
+  }
+
+  @Test(expected = AssertionError)
+  void installWithNullScript() throws Exception {
+    PythonBuilder pb = new PythonBuilder(version: '1')
+    pb.install()
+  }
+
+  @Test(expected = AssertionError)
+  void installWithNullVersion() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script)
+    pb.install()
+  }
+
+  @Test(expected = ConnectException)
+  void installWithDownloadError() throws Exception {
+    helper.registerAllowedMethod('httpRequest', [Map]) {
+      throw new ConnectException()
+    }
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1')
+    pb.install()
+  }
+
+  @Test(expected = Exception)
+  void installWithInvalidDownloadWith() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1', downloadWith: 'X')
+    pb.install()
+  }
+
+  @Test(expected = IllegalArgumentException)
+  void installWithEmptyMakeJobs() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1', makeJobs: '')
+    String pythonPath = pb.tempDir() + '/' + pb.pythonBaseName()
+    JenkinsMocks.addShMock('tar xfz ' + pythonPath + '.tgz', '', 0)
+    pb.install()
+  }
+
+  @Test(expected = NumberFormatException)
+  void installWithInvalidMakeJobs() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1', makeJobs: 'X')
+    String pythonPath = pb.tempDir() + '/' + pb.pythonBaseName()
+    JenkinsMocks.addShMock('tar xfz ' + pythonPath + '.tgz', '', 0)
+    pb.install()
+  }
+
+  @Test
+  void pythonBaseName() throws Exception {
+    PythonBuilder pb = new PythonBuilder(script: script, version: '1.0.0', revision: 'a')
+    assertEquals('Python-1.0.0a', pb.pythonBaseName())
+  }
+}

--- a/vars/pythonBuilder.groovy
+++ b/vars/pythonBuilder.groovy
@@ -1,0 +1,6 @@
+import com.ableton.PythonBuilder
+
+
+String install(Map args) {
+  return new PythonBuilder(args).install()
+}


### PR DESCRIPTION
The new PythonBuilder class will download a Python tarball from the
internet, extract it to the job's temporary directory, compile it, and
then return a string to the installation directory (also located in
the job's temporary directory). This takes about two minutes on one of
our single-core Linux nodes, but can be sped up with a number of
obvious optimizations.

The idea is to be able to test against new releases of python for
which packages are not yet available.