### PR TITLE
Use singleton for script context

### DIFF
--- a/vars/virtualenv.groovy
+++ b/vars/virtualenv.groovy
@@ -1,7 +1,6 @@
 import com.ableton.VirtualEnv
 
 
-@SuppressWarnings('MethodParameterTypeRequired')
-VirtualEnv create(def script, String python) {
-  return VirtualEnv.create(script, python)
+VirtualEnv create(String python) {
+  return VirtualEnv.create(this, python)
 }


### PR DESCRIPTION
We don't need to pass a script variable to singletons, because the
singleton has access to execute script commands. Therefore the
singleton's own `this` can be passed to the VirtualEnv ctor here.

ping @AbletonDevTools/gotham-city 