### PR TITLE
Add new class, VirtualEnvList

### DIFF
--- a/src/com/ableton/VirtualEnvList.groovy
+++ b/src/com/ableton/VirtualEnvList.groovy
@@ -1,0 +1,18 @@
+package com.ableton
+
+
+class VirtualEnvList implements Serializable {
+  @SuppressWarnings('FieldTypeRequired')
+  def script
+  List<VirtualEnv> venvs = []
+
+  void add(String python) {
+    venvs.add(VirtualEnv.create(script, python))
+  }
+
+  void run(String command) {
+    venvs.each { venv ->
+      venv.run(command)
+    }
+  }
+}

--- a/vars/virtualenvs.groovy
+++ b/vars/virtualenvs.groovy
@@ -1,0 +1,10 @@
+import com.ableton.VirtualEnvList
+
+
+VirtualEnvList create(List pythonVersions) {
+  VirtualEnvList venvs = new VirtualEnvList(script: this)
+  pythonVersions.each { python ->
+    venvs.add(python)
+  }
+  return venvs
+}


### PR DESCRIPTION
Hey @AbletonDevTools/gotham-city, I've been thinking about how we might simplify our Jenkinsfiles for projects that want to test against multiple Python versions (pretty much all of them). Currently we use this pattern:

```groovy
setup: { data ->
  def venvs = [
    virtualenv.create(this, 'python3.5'),
    virtualenv.create(this, 'python3.6'),
  ]
  venvs.each { venv ->
    venv.run('pip install -r requirements.txt')
  }
  data['venvs'] = venvs
},
test: { data ->
  parallel(
    pytest: {
      data['venvs'].each { venv ->
        venv.run('python -m pytest -rxXs tests')
      }
    }
  }
},
```

The above example is obviously condensed, but needless to say, it starts blowing up our Jenkinsfiles when we need to `each` every time we want to do a python operation. This proposed PR introduces a new class, `VirtualEnvList`, which is a thin wrapper around a collection of `VirtualEnv` objects. The above example using this class would look like so:

```groovy
setup: { data ->
  VirtualEnvList venvs = virtualenvs.create(['python3.5', 'python3.6'])
  venvs.run('pip install -r requirements.txt')
  data['venvs'] = venvs
},
test: { data ->
  parallel(data['venvs'].parallelBranches(
    pytest: { venv ->
      venv.run('python -m pytest -rxXs tests')
    }
  }
},
```

I have actually made a proof-of-concept branch on one of our private repos, which I well reference below. What do you think of this API? My hope is that it will simplify our Jenkinsfiles and make it easier to run our tests against multiple Python versions without adding a bunch of boilerplate code.