### PR TITLE
Use pipenv sync instead of pipenv install

### DIFF
--- a/src/com/ableton/Pipenv.groovy
+++ b/src/com/ableton/Pipenv.groovy
@@ -18,7 +18,7 @@ class Pipenv implements Serializable {
    * parallelized and therefore the commands are run serially for each Python version.
    *
    * This function also installs the development packages for each Python version (in
-   * other words, it runs {@code pipenv install --dev}. Also, it removes the virtualenv
+   * other words, it runs {@code pipenv sync --dev}. Also, it removes the virtualenv
    * after the last Python version has been run.
    *
    * @param pythonVersions List of Python versions to run the command with. This argument
@@ -38,7 +38,7 @@ class Pipenv implements Serializable {
 
     try {
       pythonVersions.each { python ->
-        script.sh "pipenv install --dev --python ${python}"
+        script.sh "pipenv sync --dev --python ${python}"
         results[python] = body(python)
       }
     } finally {

--- a/test/com/ableton/PipenvTest.groovy
+++ b/test/com/ableton/PipenvTest.groovy
@@ -36,7 +36,7 @@ class PipenvTest extends BasePipelineTest {
   void runWith() throws Exception {
     List pythonVersions = ['2.7', '3.5']
     pythonVersions.each { python ->
-      JenkinsMocks.addShMock("pipenv install --dev --python ${python}", '', 0)
+      JenkinsMocks.addShMock("pipenv sync --dev --python ${python}", '', 0)
     }
 
     int numCalls = 0
@@ -45,12 +45,12 @@ class PipenvTest extends BasePipelineTest {
       return p
     }
 
-    // Ensure that pipenv install was called for each Python version
+    // Ensure that pipenv sync was called for each Python version
     pythonVersions.each { python ->
       assertTrue(helper.callStack.findAll { call ->
         call.methodName == 'sh'
       }.any { call ->
-        callArgsToString(call).contains("pipenv install --dev --python ${python}")
+        callArgsToString(call).contains("pipenv sync --dev --python ${python}")
       })
     }
 


### PR DESCRIPTION
Install is an alias for lock + sync, which can update packages
unexpectedly. We should always use sync when installing packages on
CI.

---

ping @AbletonDevTools/gotham-city 