### PR TITLE
Fix JitPack URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'groovy'
 repositories {
   mavenCentral()
   maven {
-    url 'https://jitpack.io'
+    url 'https://www.jitpack.io'
   }
 }
 


### PR DESCRIPTION
JitPack's DNS configuration points the non-www name to a broken CDN
configuration on CloudFlare, so the easy workaround here is just to
point their URL to the www subdomain. See:

https://github.com/expo/expo/commit/bb2d4b04845f6e4813e51b02149c3f5eef1b606b